### PR TITLE
properly handle window closing

### DIFF
--- a/src/Window.hs
+++ b/src/Window.hs
@@ -50,7 +50,7 @@ updateWindow window = do
 
     return $ window
         { _inputState = inputState
-        , _closed     = QuitEvent `elem` inputEvents
+        , _closed     = _closed window || QuitEvent `elem` inputEvents
         }
 
 processWindowGraphicsEvents


### PR DESCRIPTION
fixes bug i was experiencing in bspwm with the game not exiting when i close the window (linux/x11)

not sure if the bug also affects other platforms, though i suspect it might. i added some debug print statements and saw that SDL.Close does get handled correctly, though the window state gets reset back to `{_closed = True}` before this section in `gameMain` is triggered (see https://github.com/incoherentsoftware/defect-process/blob/15f2569/src/Game.hs#L142):

```hs
gameMain :: AppEnvData -> Window -> Game -> IO ()
gameMain appEnvData window game = do
    (window', configs, game') <- runAppEnv appEnvData $ do
        (win, cfgs, gm) <- updateGame window game

        when (_closed win || _quit gm) $
            freeGraphicsAndExit
```